### PR TITLE
Add some functions to the package init

### DIFF
--- a/properimage/__init__.py
+++ b/properimage/__init__.py
@@ -15,3 +15,6 @@ hypothesis test scheme.
 """
 
 __version__ = "0.7"
+
+from .operations import subtract, coadd
+from .single_image import SingleImage

--- a/properimage/__init__.py
+++ b/properimage/__init__.py
@@ -18,3 +18,5 @@ __version__ = "0.7"
 
 from .operations import subtract, coadd
 from .single_image import SingleImage
+
+__all__ = ["subtract", "coadd", "SingleImage"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,7 +32,7 @@ from numpy.random import default_rng
 
 import pytest
 
-from properimage import single_image as s, simtools
+from properimage import SingleImage, simtools
 
 
 # =============================================================================
@@ -61,7 +61,7 @@ def random_simage():
     for i in range(10):
         mask = mask & random.integers(2, size=(128, 128))
 
-    img = s.SingleImage(pixel, mask)
+    img = SingleImage(pixel, mask)
 
     return img
 
@@ -106,4 +106,4 @@ def random_4psf_simage():
                 i + 2 * j
             ]
 
-    return s.SingleImage(frame)
+    return SingleImage(frame)

--- a/tests/test_propercoadd.py
+++ b/tests/test_propercoadd.py
@@ -34,8 +34,8 @@ from numpy.random import default_rng
 
 from astropy.io import fits
 
-from properimage import operations as op
-from properimage import single_image as si
+from properimage import coadd
+from properimage import SingleImage
 from properimage import simtools
 from properimage import utils
 
@@ -86,7 +86,7 @@ class PropercoaddBase(object):
             self.paths.append(mockfits_path)
 
     def testChunkIt(self):
-        imgs = [si.SingleImage(img) for img in self.paths]
+        imgs = [SingleImage(img) for img in self.paths]
 
         for i in range(len(imgs)):
             chunks = utils.chunk_it(imgs, i + 1)
@@ -109,10 +109,10 @@ class PropercoaddBase(object):
 class TestCoaddSingleCore(PropercoaddBase, ProperImageTestCase):
     def setUp(self):
         super(TestCoaddSingleCore, self).setUp()
-        self.imgs = [si.SingleImage(img) for img in self.paths]
+        self.imgs = [SingleImage(img) for img in self.paths]
 
     def testCoaddSingleCore(self):
-        R, P_r, mask = op.coadd(self.imgs, align=False, n_procs=1)
+        R, P_r, mask = coadd(self.imgs, align=False, n_procs=1)
         self.assertIsInstance(R, np.ndarray)
         self.assertIsInstance(P_r, np.ndarray)
         self.assertIsInstance(mask, np.ndarray)
@@ -121,10 +121,10 @@ class TestCoaddSingleCore(PropercoaddBase, ProperImageTestCase):
 class TestCoadd2Core(PropercoaddBase, ProperImageTestCase):
     def setUp(self):
         super(TestCoadd2Core, self).setUp()
-        self.imgs = [si.SingleImage(img) for img in self.paths]
+        self.imgs = [SingleImage(img) for img in self.paths]
 
     def testCoadd2Core(self):
-        R, P_r, mask = op.coadd(self.imgs, align=False, n_procs=2)
+        R, P_r, mask = coadd(self.imgs, align=False, n_procs=2)
         self.assertIsInstance(R, np.ndarray)
         self.assertIsInstance(P_r, np.ndarray)
         self.assertIsInstance(mask, np.ndarray)
@@ -133,11 +133,11 @@ class TestCoadd2Core(PropercoaddBase, ProperImageTestCase):
 class TestCoaddMultCore1(PropercoaddBase, ProperImageTestCase):
     def setUp(self):
         super(TestCoaddMultCore1, self).setUp()
-        self.imgs = [si.SingleImage(img) for img in self.paths]
+        self.imgs = [SingleImage(img) for img in self.paths]
 
     def testCoaddMultipleCores(self):
-        R2, P_r2, mask2 = op.coadd(self.imgs, align=False, n_procs=2)
-        R, P_r, mask = op.coadd(self.imgs, align=False, n_procs=1)
+        R2, P_r2, mask2 = coadd(self.imgs, align=False, n_procs=2)
+        R, P_r, mask = coadd(self.imgs, align=False, n_procs=1)
 
         np.testing.assert_allclose(R.real, R2.real, rtol=0.2, atol=0.5)
         np.testing.assert_allclose(P_r.real, P_r2.real, rtol=0.2, atol=0.5)
@@ -147,11 +147,11 @@ class TestCoaddMultCore1(PropercoaddBase, ProperImageTestCase):
 class TestCoaddMultCore2(PropercoaddBase, ProperImageTestCase):
     def setUp(self):
         super(TestCoaddMultCore2, self).setUp()
-        self.imgs = [si.SingleImage(img) for img in self.paths]
+        self.imgs = [SingleImage(img) for img in self.paths]
 
     def testCoaddMultipleCores(self):
-        R2, P_r2, mask2 = op.coadd(self.imgs, align=False, n_procs=4)
-        R, P_r, mask = op.coadd(self.imgs, align=False, n_procs=2)
+        R2, P_r2, mask2 = coadd(self.imgs, align=False, n_procs=4)
+        R, P_r, mask = coadd(self.imgs, align=False, n_procs=2)
 
         np.testing.assert_allclose(R.real, R2.real, rtol=0.2, atol=0.5)
         np.testing.assert_allclose(P_r.real, P_r2.real, rtol=0.2, atol=0.5)

--- a/tests/test_propersubtract.py
+++ b/tests/test_propersubtract.py
@@ -35,8 +35,8 @@ from numpy.random import default_rng
 
 from astropy.io import fits
 
-from properimage import operations as op
-from properimage import single_image as si
+from properimage import subtract
+from properimage import SingleImage
 from properimage import simtools
 
 
@@ -109,11 +109,11 @@ class PropersubtractBase(object):
 class TestSubtract(PropersubtractBase, unittest.TestCase):
     def setUp(self):
         super(TestSubtract, self).setUp()
-        self.si_ref = si.SingleImage(self.paths[0])
-        self.si_new = si.SingleImage(self.paths[1])
+        self.si_ref = SingleImage(self.paths[0])
+        self.si_new = SingleImage(self.paths[1])
 
     def testSubtractNoBeta(self):
-        D, P, S_corr, mix_mask = op.subtract(
+        D, P, S_corr, mix_mask = subtract(
             self.si_ref, self.si_new, beta=False
         )
         self.assertIsInstance(D, np.ndarray)
@@ -122,7 +122,7 @@ class TestSubtract(PropersubtractBase, unittest.TestCase):
         self.assertIsInstance(mix_mask, np.ndarray)
 
     def testSubtractBetaIterative(self):
-        D, P, S_corr, mix_mask = op.subtract(
+        D, P, S_corr, mix_mask = subtract(
             self.si_ref, self.si_new, beta=True, iterative=True, shift=False
         )
         self.assertIsInstance(D, np.ndarray)
@@ -131,7 +131,7 @@ class TestSubtract(PropersubtractBase, unittest.TestCase):
         self.assertIsInstance(mix_mask, np.ndarray)
 
     def testSubtractBetaShift(self):
-        D, P, S_corr, mix_mask = op.subtract(
+        D, P, S_corr, mix_mask = subtract(
             self.si_ref, self.si_new, beta=True, iterative=False, shift=True
         )
         self.assertIsInstance(D, np.ndarray)
@@ -140,7 +140,7 @@ class TestSubtract(PropersubtractBase, unittest.TestCase):
         self.assertIsInstance(mix_mask, np.ndarray)
 
     def testSubtractOnlyBeta(self):
-        D, P, S_corr, mix_mask = op.subtract(
+        D, P, S_corr, mix_mask = subtract(
             self.si_ref, self.si_new, beta=True, iterative=False, shift=False
         )
         self.assertIsInstance(D, np.ndarray)
@@ -149,7 +149,7 @@ class TestSubtract(PropersubtractBase, unittest.TestCase):
         self.assertIsInstance(mix_mask, np.ndarray)
 
     def testSubtractOnlyShift(self):
-        D, P, S_corr, mix_mask = op.subtract(
+        D, P, S_corr, mix_mask = subtract(
             self.si_ref, self.si_new, beta=False, iterative=False, shift=True
         )
         self.assertIsInstance(D, np.ndarray)
@@ -158,7 +158,7 @@ class TestSubtract(PropersubtractBase, unittest.TestCase):
         self.assertIsInstance(mix_mask, np.ndarray)
 
     def testSubtractNoFitPSF(self):
-        D, P, S_corr, mix_mask = op.subtract(
+        D, P, S_corr, mix_mask = subtract(
             self.si_ref,
             self.si_new,
             beta=False,

--- a/tests/test_single_image.py
+++ b/tests/test_single_image.py
@@ -34,7 +34,7 @@ from numpy.random import default_rng
 
 from astropy.io import fits
 
-from properimage import single_image as s
+from properimage import SingleImage
 from properimage import simtools
 
 import pytest
@@ -265,7 +265,7 @@ class TestNpArray(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestNpArray, self).setUp()
         print(self.mock_image_data.shape)
-        self.si = s.SingleImage(self.mock_image_data)
+        self.si = SingleImage(self.mock_image_data)
 
     def testMask(self):
         nanmask = np.zeros((256, 256))
@@ -279,7 +279,7 @@ class TestNpArray(SingleImageBase, ProperImageTestCase):
 class TestNpArrayMask(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestNpArrayMask, self).setUp()
-        self.si = s.SingleImage(self.mock_image_data, self.mock_image_mask)
+        self.si = SingleImage(self.mock_image_data, self.mock_image_mask)
 
     def testHeader(self):
         self.assertDictEqual(self.si.header, {})
@@ -288,7 +288,7 @@ class TestNpArrayMask(SingleImageBase, ProperImageTestCase):
 class TestFitsFile(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestFitsFile, self).setUp()
-        self.si = s.SingleImage(self.mockfits_path)
+        self.si = SingleImage(self.mockfits_path)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, self.mockfits_path)
@@ -305,7 +305,7 @@ class TestFitsFile(SingleImageBase, ProperImageTestCase):
 class TestFitsMask(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestFitsMask, self).setUp()
-        self.si = s.SingleImage(self.mockfits_path, mask=self.mockmask_path)
+        self.si = SingleImage(self.mockfits_path, mask=self.mockmask_path)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, self.mockfits_path)
@@ -317,7 +317,7 @@ class TestFitsMask(SingleImageBase, ProperImageTestCase):
 class TestHDU(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestHDU, self).setUp()
-        self.si = s.SingleImage(self.mockimageHdu)
+        self.si = SingleImage(self.mockimageHdu)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, "PrimaryHDU")
@@ -334,7 +334,7 @@ class TestHDU(SingleImageBase, ProperImageTestCase):
 class TestHDUList(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestHDUList, self).setUp()
-        self.si = s.SingleImage(self.mock_masked_hdu)
+        self.si = SingleImage(self.mock_masked_hdu)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, "HDUList")
@@ -346,7 +346,7 @@ class TestHDUList(SingleImageBase, ProperImageTestCase):
 class TestFitsExtension(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestFitsExtension, self).setUp()
-        self.si = s.SingleImage(self.masked_hdu_path)
+        self.si = SingleImage(self.masked_hdu_path)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, self.masked_hdu_path)
@@ -361,7 +361,7 @@ class TestNoSources(ProperImageTestCase):
 
     def testNoSources(self):
         with self.assertRaises(ValueError):
-            s.SingleImage(self.no_sources_image)
+            SingleImage(self.no_sources_image)
 
 
 class TestNpArrayMinSrcs(SingleImageBase, ProperImageTestCase):
@@ -395,7 +395,7 @@ class TestNpArrayPicky(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestNpArrayPicky, self).setUp()
         print(self.mock_image_data.shape)
-        self.si = s.SingleImage(self.mock_image_data, strict_star_pick=True)
+        self.si = SingleImage(self.mock_image_data, strict_star_pick=True)
 
     def testMask(self):
         nanmask = np.zeros((256, 256))
@@ -409,7 +409,7 @@ class TestNpArrayPicky(SingleImageBase, ProperImageTestCase):
 class TestNpArrayMaskPicky(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestNpArrayMaskPicky, self).setUp()
-        self.si = s.SingleImage(
+        self.si = SingleImage(
             self.mock_image_data, self.mock_image_mask, strict_star_pick=True
         )
 
@@ -420,7 +420,7 @@ class TestNpArrayMaskPicky(SingleImageBase, ProperImageTestCase):
 class TestFitsFilePicky(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestFitsFilePicky, self).setUp()
-        self.si = s.SingleImage(self.mockfits_path, strict_star_pick=True)
+        self.si = SingleImage(self.mockfits_path, strict_star_pick=True)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, self.mockfits_path)
@@ -437,7 +437,7 @@ class TestFitsFilePicky(SingleImageBase, ProperImageTestCase):
 class TestFitsMaskPicky(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestFitsMaskPicky, self).setUp()
-        self.si = s.SingleImage(
+        self.si = SingleImage(
             self.mockfits_path, mask=self.mockmask_path, strict_star_pick=True
         )
 
@@ -451,7 +451,7 @@ class TestFitsMaskPicky(SingleImageBase, ProperImageTestCase):
 class TestHDUPicky(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestHDUPicky, self).setUp()
-        self.si = s.SingleImage(self.mockimageHdu, strict_star_pick=True)
+        self.si = SingleImage(self.mockimageHdu, strict_star_pick=True)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, "PrimaryHDU")
@@ -468,7 +468,7 @@ class TestHDUPicky(SingleImageBase, ProperImageTestCase):
 class TestHDUListPicky(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestHDUListPicky, self).setUp()
-        self.si = s.SingleImage(self.mock_masked_hdu, strict_star_pick=True)
+        self.si = SingleImage(self.mock_masked_hdu, strict_star_pick=True)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, "HDUList")
@@ -480,7 +480,7 @@ class TestHDUListPicky(SingleImageBase, ProperImageTestCase):
 class TestFitsExtensionPicky(SingleImageBase, ProperImageTestCase):
     def setUp(self):
         super(TestFitsExtensionPicky, self).setUp()
-        self.si = s.SingleImage(self.masked_hdu_path)
+        self.si = SingleImage(self.masked_hdu_path)
 
     def testAttachedTo(self):
         self.assertEqual(self.si.attached_to, self.masked_hdu_path)
@@ -495,4 +495,4 @@ class TestNoSourcesPicky(ProperImageTestCase):
 
     def testNoSources(self):
         with self.assertRaises(ValueError):
-            s.SingleImage(self.no_sources_image)
+            SingleImage(self.no_sources_image)


### PR DESCRIPTION
Adds `subtract`, `coadd` and `SingleImage` to `properimage`'s scope.

So instead of doing:

    from properimage.single_image import SingleImage

you can do:

    from properimage import SingleImage

